### PR TITLE
Suggested changes in packages versioning in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ A series of lessons on using python for ML
 
 Should work in the following Python environment:
 ```
-conda create -n ml_env python=3.8 pip
+conda create -n ml_env python=3.6 pip
 conda activate ml_env
 
 conda install tensorflow==1.9
 conda install Keras==2.1.6
 conda install pandas==0.23.3
-conda install gensim==3.5.0
 conda install matplotlib==2.2.3
 conda install jupyter==1.0.0
-conda install numpy==1.17.3
-conda install scipy==1.2.0
 conda install scikit-learn==0.19.1
 conda install seaborn==0.9.0
+
+pip install -U gensim
 
 # for Lesson 06
 pip install talos 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ conda install matplotlib==2.2.3
 conda install jupyter==1.0.0
 conda install scikit-learn==0.19.1
 conda install seaborn==0.9.0
-
-pip install -U gensim
+conda install gensim==3.8.0
 
 # for Lesson 06
 pip install talos 


### PR DESCRIPTION
Tensorflow 1.9 won't install for python 3.8. It requires python 3.6.

It's unecessery to install scipy and numpy because it's referenced by other libraries so the versions will be downgraded (numpy to 1.14.2 and scipy to 1.1.0).

Couldn't install gensim by conda (many versioning errors) so I installed it's latest version by pip and than lesson 5 starts to work perfectly.